### PR TITLE
Add an option to hit closed paths with transparent or alpha 0 fill

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -1894,6 +1894,8 @@ new function() { // Injection scope for hit-test functions shared with project
      * @option options.guides {Boolean} hit-test items that have {@link
      *     Item#guide} set to `true`
      * @option options.selected {Boolean} only hit selected items
+     * @option options.hitUnfilledPaths {Boolean} Allow hitting null or alpha 0
+     *     fills for paths
      *
      * @param {Point} point the point where the hit-test should be performed
      * @param {Object} [options={ fill: true, stroke: true, segments: true,

--- a/src/path/Path.js
+++ b/src/path/Path.js
@@ -1660,7 +1660,8 @@ var Path = PathItem.extend(/** @lends Path# */{
             join, cap, miterLimit,
             area, loc, res,
             hitStroke = options.stroke && style.hasStroke(),
-            hitFill = options.fill && style.hasFill(),
+            hitFill = options.hitUnfilledPaths
+                ? options.fill : options.fill && style.hasFill(),
             hitCurves = options.curves,
             strokeRadius = hitStroke
                     ? style.getStrokeWidth() / 2


### PR DESCRIPTION
This will allow us to implement the fill tool, which should be able to fill empty spaces.