### PR TITLE
Paper core

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "Jürg Lehni <juerg@scratchdisk.com> (http://scratchdisk.com)",
     "Jonathan Puckey <jonathan@studiomoniker.com> (http://studiomoniker.com)"
   ],
-  "main": "dist/paper-full.js",
+  "main": "dist/paper-core.js",
   "scripts": {
     "precommit": "gulp jshint --branch develop",
     "prepush": "gulp test --branch develop",


### PR DESCRIPTION
Use paper-core instead of paper-full, since Scratch doesn't use any of the extra features of paper-full.

Size change
 scratch-paint.js  2.09 MB
 scratch-paint.js  1.96 MB