### PR TITLE
Allow hitting unfilled text and compound paths when hitUnfilledPaths option is on

### DIFF
--- a/src/path/CompoundPath.js
+++ b/src/path/CompoundPath.js
@@ -293,7 +293,7 @@ var CompoundPath = PathItem.extend(/** @lends CompoundPath# */{
                 // options.class == Path, do not test children for fill, since a
                 // compound path forms one shape.
                 // Also support legacy format `type: 'path'`.
-                options.class === Path || options.type === 'path' ? options
+                options.class === Path || options.type === 'path' || options.hitUnfilledPaths ? options
                     : Base.set({}, options, { fill: false }),
                 viewMatrix);
     },

--- a/src/text/PointText.js
+++ b/src/text/PointText.js
@@ -119,5 +119,10 @@ var PointText = TextItem.extend(/** @lends PointText# */{
                     numLines ? - 0.75 * leading : 0,
                     width, numLines * leading);
         return matrix ? matrix._transformBounds(rect, rect) : rect;
+    },
+
+    _hitTestSelf: function(point, options) {
+        if (options.fill && (this.hasFill() || options.hitUnfilledPaths) && this._contains(point))
+            return new HitResult('fill', this);
     }
 });


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-paint/issues/357

Compound paths have special logic to not detect hits on children unless the hit options are explicitly set to find paths. In https://github.com/LLK/scratch-paint/commit/8d61a7b0602d76b26edb46f9b89fde72716609b1#diff-290c24d7c42d95aa6e9f39b38eb336a2L41 I changed the hit options from detecting paths to detecting both paths and text items, which broke this. The hitUnfilledPaths option implies that we're interested in paths, so it should work as if the class were set to Path.

Additionally, I've added support for the hitUnfilledPaths option to PointText. This makes transparent text detectable by the fill tool.