### PR TITLE
Fix SVG import of translate with one argument

### DIFF
--- a/src/svg/SvgImport.js
+++ b/src/svg/SvgImport.js
@@ -375,7 +375,8 @@ new function() {
                             new Matrix(v[0], v[1], v[2], v[3], v[4], v[5]));
                     break;
                 case 'rotate':
-                    matrix.rotate(v[0], v[1], v[2]);
+                    var v2 = (typeof v[1] === 'number' && typeof v[2] !== 'number') ? 0 : v[2];
+                    matrix.rotate(v[0], v[1], v2);
                     break;
                 case 'translate':
                     var v1 = (typeof v[1] === 'number') ? v[1] : 0;

--- a/src/svg/SvgImport.js
+++ b/src/svg/SvgImport.js
@@ -378,7 +378,8 @@ new function() {
                     matrix.rotate(v[0], v[1], v[2]);
                     break;
                 case 'translate':
-                    matrix.translate(v[0], v[1]);
+                    var v1 = (typeof v[1] === 'number') ? v[1] : 0;
+                    matrix.translate(v[0], v1);
                     break;
                 case 'scale':
                     matrix.scale(v);


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-gui/issues/2290

For SVG import, If second argument is missing in translate, assume that it's zero. Currently it assumes that y matches x if y is missing.