### PR TITLE
Fix Safari when selection exceeds canvas bounds

### DIFF
--- a/src/item/Raster.js
+++ b/src/item/Raster.js
@@ -443,8 +443,16 @@ var Raster = Item.extend(/** @lends Raster# */{
     getSubCanvas: function(/* rect */) {
         var rect = Rectangle.read(arguments),
             ctx = CanvasProvider.getContext(rect.getSize());
-        ctx.drawImage(this.getCanvas(), rect.x, rect.y,
-                rect.width, rect.height, 0, 0, rect.width, rect.height);
+        const clippedStartX = Math.max(0, rect.x);
+        const clippedStartY = Math.max(0, rect.y);
+        const clippedEndX = Math.min(this.getCanvas().width, rect.x + rect.width);
+        const clippedEndY = Math.min(this.getCanvas().height, rect.y + rect.height);
+        ctx.drawImage(this.getCanvas(),
+            clippedStartX, clippedStartY,
+            clippedEndX - clippedStartX, clippedEndY - clippedStartY,
+            clippedStartX - rect.x, clippedStartY - rect.y,
+            clippedEndX - clippedStartX, clippedEndY - clippedStartY
+        );
         return ctx.canvas;
     },
 


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-paint/issues/568

Sampling outside the bounds of the canvas returns a fully blank canvas in Safari. In all other browsers, pixels outside the bounds of the canvas are considered transparent. This fix makes getSubRaster sample only pixels within the canvas, and draw them onto a transparent canvas of the right size, so that the behavior matches other browsers.