### PR TITLE
Measure text

### DIFF
--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -18,7 +18,8 @@ var gulp = require('gulp'),
 
 gulp.task('test', function(callback) {
     runSequence(
-        'build'
+        'build',
+        'jshint'
         // 'test:postbuild' // Disable tests for getting text stuff out
     );
 });

--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -836,7 +836,8 @@ new function() { // Injection scope for various item event handlers
         getStrokeBounds: { stroke: true },
         getHandleBounds: { handle: true },
         getInternalBounds: { internal: true },
-        getVisibleBounds: { stroke: true, forSvgExport: true },
+        // Includes text overhangs
+        getDrawnBounds: { stroke: true, drawnTextBounds: true },
     },
     function(options, key) {
         this[key] = function(matrix) {
@@ -932,6 +933,7 @@ new function() { // Injection scope for various item event handlers
         return [
             options.stroke ? 1 : 0,
             options.handle ? 1 : 0,
+            options.drawnTextBounds? 1 : 0,
             internal ? 1 : 0
         ].join('');
     },

--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -835,7 +835,8 @@ new function() { // Injection scope for various item event handlers
 }, Base.each({ // Produce getters for bounds properties:
         getStrokeBounds: { stroke: true },
         getHandleBounds: { handle: true },
-        getInternalBounds: { internal: true }
+        getInternalBounds: { internal: true },
+        getVisibleBounds: { stroke: true, forSvgExport: true },
     },
     function(options, key) {
         this[key] = function(matrix) {

--- a/src/svg/SvgExport.js
+++ b/src/svg/SvgExport.js
@@ -438,7 +438,7 @@ new function() {
                 rect = bounds === 'view'
                     ? new Rectangle([0, 0], view.getViewSize())
                     : bounds === 'content'
-                        ? Item._getBounds(children, matrix, { stroke: true })
+                        ? Item._getBounds(children, matrix, { stroke: true, forSvgExport: true })
                             .rect
                         : Rectangle.read([bounds], 0, { readNull: true }),
                 attrs = {

--- a/src/svg/SvgExport.js
+++ b/src/svg/SvgExport.js
@@ -438,7 +438,7 @@ new function() {
                 rect = bounds === 'view'
                     ? new Rectangle([0, 0], view.getViewSize())
                     : bounds === 'content'
-                        ? Item._getBounds(children, matrix, { stroke: true, forSvgExport: true })
+                        ? Item._getBounds(children, matrix, { stroke: true, drawnTextBounds: true })
                             .rect
                         : Rectangle.read([bounds], 0, { readNull: true }),
                 attrs = {

--- a/src/svg/SvgImport.js
+++ b/src/svg/SvgImport.js
@@ -140,6 +140,7 @@ new function() {
     }
 
     function importGradient(node, type) {
+        debugger;
         var id = (getValue(node, 'href', true) || '').substring(1),
             radial = type === 'radialgradient',
             gradient;

--- a/src/svg/SvgImport.js
+++ b/src/svg/SvgImport.js
@@ -140,7 +140,6 @@ new function() {
     }
 
     function importGradient(node, type) {
-        debugger;
         var id = (getValue(node, 'href', true) || '').substring(1),
             radial = type === 'radialgradient',
             gradient;

--- a/src/text/PointText.js
+++ b/src/text/PointText.js
@@ -105,7 +105,7 @@ var PointText = TextItem.extend(/** @lends PointText# */{
         var rect = options.drawnTextBounds ? this._getDrawnTextSize() : this._getMeasuredTextSize();
         return matrix ? matrix._transformBounds(rect, rect) : rect;
     },
-    _getMeasuredTextSize () {
+    _getMeasuredTextSize: function() {
         var style = this._style,
             lines = this._lines,
             numLines = lines.length,
@@ -122,7 +122,7 @@ var PointText = TextItem.extend(/** @lends PointText# */{
                     numLines ? - 0.75 * leading : 0,
                     width, numLines * leading);
     },
-    _getDrawnTextSize () {
+    _getDrawnTextSize: function() {
         var numLines = this._lines.length;
         var leading = this._style.getLeading();
 
@@ -132,7 +132,7 @@ var PointText = TextItem.extend(/** @lends PointText# */{
                     xmlns: SvgElement.svg
                 });
         var node = SvgElement.create('text');
-        node.setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:space', 'preserve')
+        node.setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:space', 'preserve');
         svg.appendChild(node);
         for (var i = 0; i < numLines; i++) {
             var tspanNode = SvgElement.create('tspan', {
@@ -147,7 +147,7 @@ var PointText = TextItem.extend(/** @lends PointText# */{
         var element = document.createElement('span');
         element.style.visibility = ('hidden');
         element.style.whiteSpace = 'pre';
-        element.style.fontSize = `${this.fontSize}px`;
+        element.style.fontSize = this.fontSize + 'px';
         element.style.fontFamily = this.font;
         element.style.lineHeight = this.leading / this.fontSize;
 

--- a/src/text/PointText.js
+++ b/src/text/PointText.js
@@ -101,10 +101,12 @@ var PointText = TextItem.extend(/** @lends PointText# */{
             ctx.translate(0, leading);
         }
     },
+
     _getBounds: function(matrix, options) {
         var rect = options.drawnTextBounds ? this._getDrawnTextSize() : this._getMeasuredTextSize();
         return matrix ? matrix._transformBounds(rect, rect) : rect;
     },
+
     _getMeasuredTextSize: function() {
         var style = this._style,
             lines = this._lines,
@@ -122,6 +124,7 @@ var PointText = TextItem.extend(/** @lends PointText# */{
                     numLines ? - 0.75 * leading : 0,
                     width, numLines * leading);
     },
+
     _getDrawnTextSize: function() {
         var style = this._style;
         var lines = this._lines;
@@ -185,6 +188,7 @@ var PointText = TextItem.extend(/** @lends PointText# */{
         // Add 1 to give space for text cursor
         return new Rectangle(x, y, width + 1, Math.max(height, numLines * leading));
     },
+
     _hitTestSelf: function(point, options) {
         if (options.fill && (this.hasFill() || options.hitUnfilledPaths) && this._contains(point))
             return new HitResult('fill', this);

--- a/src/text/PointText.js
+++ b/src/text/PointText.js
@@ -123,8 +123,11 @@ var PointText = TextItem.extend(/** @lends PointText# */{
                     width, numLines * leading);
     },
     _getDrawnTextSize: function() {
-        var numLines = this._lines.length;
-        var leading = this._style.getLeading();
+        var style = this._style;
+        var lines = this._lines;
+        var numLines = lines.length;
+        var leading = style.getLeading();
+        var justification = style.getJustification();
 
         // Create SVG dom element from text
         var svg = SvgElement.create('svg', {
@@ -172,6 +175,12 @@ var PointText = TextItem.extend(/** @lends PointText# */{
         var height = bbox.height + (halfStrokeWidth * 2);
         var x = bbox.x - halfStrokeWidth;
         var y = bbox.y - halfStrokeWidth;
+
+        // Adjust for different justifications.
+        if (justification !== 'left') {
+            var eltWidth = this.getView().getTextWidth(style.getFontStyle(), lines);
+            x -= eltWidth / (justification === 'center' ? 2: 1);
+        }
 
         // Add 1 to give space for text cursor
         return new Rectangle(x, y, width + 1, Math.max(height, numLines * leading));

--- a/src/text/PointText.js
+++ b/src/text/PointText.js
@@ -102,12 +102,10 @@ var PointText = TextItem.extend(/** @lends PointText# */{
         }
     },
     _getBounds: function(matrix, options) {
-        var rect = options.forSvgExport ? this._getVisibleTextSize() : this._getMeasuredTextSize();
-        console.log(rect);
+        var rect = options.drawnTextBounds ? this._getDrawnTextSize() : this._getMeasuredTextSize();
         return matrix ? matrix._transformBounds(rect, rect) : rect;
     },
     _getMeasuredTextSize () {
-        console.log("get measured text size");
         var style = this._style,
             lines = this._lines,
             numLines = lines.length,
@@ -124,8 +122,7 @@ var PointText = TextItem.extend(/** @lends PointText# */{
                     numLines ? - 0.75 * leading : 0,
                     width, numLines * leading);
     },
-    _getVisibleTextSize () {
-        console.log("get visible text size");
+    _getDrawnTextSize () {
         var numLines = this._lines.length;
         var leading = this._style.getLeading();
 


### PR DESCRIPTION
This is part of the fix for https://github.com/LLK/scratch-paint/issues/434

1. paper.Item now provides drawnBounds, which allows users to measure the size of the text including overflow from the bounds. Drawn bounds is obtained by converting the text to SVG and measuring the SVG in the dom. Measurement function is based on _transformMeasurements in SVGRenderer.
2. Use drawn bounds when exporting SVGs so that edges of text don't get clipped

Before:
![image](https://user-images.githubusercontent.com/2855464/47525305-e7175880-d86a-11e8-93d9-52e287079abe.png)

After: (With paint pr)
![image](https://user-images.githubusercontent.com/2855464/47525212-ab7c8e80-d86a-11e8-8a36-7d41f35e6806.png)

