### PR TITLE
Set preserve spaces, and insert spaces on blank lines when exporting text from Paint

### DIFF
--- a/src/svg/SvgExport.js
+++ b/src/svg/SvgExport.js
@@ -265,6 +265,7 @@ new function() {
         var node = SvgElement.create('text', getTransform(item._matrix, false),
                 formatter);
         node.setAttribute('font-size', item.fontSize);
+        node.setAttribute('xml:space', 'preserve');
         for (var i = 0; i < item._lines.length; i++) {
             // Scratch-specific: Use <tspan> for multiline text,
             // right now only supports left justified (x=0)
@@ -272,7 +273,7 @@ new function() {
                 x: '0',
                 dy: i === 0 ? '0' : item.getLeading() + 'px'
             }, formatter);
-            tspanNode.textContent = item._lines[i];
+            tspanNode.textContent = item._lines[i] ? item._lines[i] : ' ';
             node.appendChild(tspanNode);
         }
         return node;


### PR DESCRIPTION
Partially fixes https://github.com/LLK/scratch-render/issues/292

Export text from paint with preserve spaces, and add a space to empty newlines to preserve newlines when displayed in the renderer.

When the text is reimported into the paint editor, it will have spaces on all the empty lines, which is admittedly kind of weird.