### PR TITLE
Test for getAttribute before calling

### DIFF
--- a/src/svg/SvgImport.js
+++ b/src/svg/SvgImport.js
@@ -316,8 +316,8 @@ new function() {
                 // Does not support x/y attribute or tspan positioning beyond left justified.
                 var lines = [];
                 var spacing = 1.2;
-                for (var i = 0; i < node.childNodes.length; i++) {
-                    var child = node.childNodes[i];
+                for (var i = 0; i < node.children.length; i++) {
+                    var child = node.children[i];
                     lines.push(child.textContent);
                     var dyString = child.getAttribute('dy');
                     if (dyString) {

--- a/src/svg/SvgImport.js
+++ b/src/svg/SvgImport.js
@@ -318,6 +318,9 @@ new function() {
                 var spacing = 1.2;
                 for (var i = 0; i < node.childNodes.length; i++) {
                     var child = node.childNodes[i];
+                    // node.childNodes includes plaintext as well as elements.
+                    // By checking for getAttribute, we ignore plaintext
+                    // (node.children gets only elements but is not supported on Safari)
                     if (!child.getAttribute) continue;
                     lines.push(child.textContent);
                     var dyString = child.getAttribute('dy');

--- a/src/svg/SvgImport.js
+++ b/src/svg/SvgImport.js
@@ -316,8 +316,9 @@ new function() {
                 // Does not support x/y attribute or tspan positioning beyond left justified.
                 var lines = [];
                 var spacing = 1.2;
-                for (var i = 0; i < node.children.length; i++) {
-                    var child = node.children[i];
+                for (var i = 0; i < node.childNodes.length; i++) {
+                    var child = node.childNodes[i];
+                    if (!child.getAttribute) continue;
                     lines.push(child.textContent);
                     var dyString = child.getAttribute('dy');
                     if (dyString) {


### PR DESCRIPTION
Fixes https://github.com/LLK/scratch-paint/issues/866

We expect SVG text tags to be one of 2 formats:
- The tag contains only text as a child
- The tag contains only tspan tags as children

This change fixes the crash if the tag contains a mix of text and tspans. In the case that the text tag contains any tags, we ignore childNodes that don't have getAttribute, which means they are not inside tags.

Note that the result for project 167167477 is that the text elements in the platform sprite lose their x, y position and are moved to (0, 0). This isn't ideal :/, but hopefully it's not too impactful since svgs from scratch 2 would not include tspans unless they were imported. (We ignore x and y because scratch 2 exports assets with x and y set incorrectly on text)