### PR TITLE
Don't apply undefined styles in exportSVG + handle invalid fill-rule in importer

### DIFF
--- a/src/svg/SvgExport.js
+++ b/src/svg/SvgExport.js
@@ -304,6 +304,12 @@ new function() {
             var get = entry.get,
                 type = entry.type,
                 value = item[get]();
+
+            // In some cases, the style's value is undefined. Trying to save it
+            // will result in erroneous behavior; for instance, properties like
+            // "fill-rule" will have the invalid value of "none" if undefined.
+            if (value === undefined) return;
+
             if (entry.exportFilter
                     ? entry.exportFilter(item, value)
                     : !parent || !Base.equals(parent[get](), value) ||

--- a/src/svg/SvgImport.js
+++ b/src/svg/SvgImport.js
@@ -531,7 +531,14 @@ new function() {
                 if (matrix)
                     group.transform(matrix);
             }
-        }
+        },
+
+        'fill-rule': function(item, value) {
+            // Sometimes, the fill-rule attribute will be set to "none" due to a paper.js bug.
+            // This is coerced into a `null`. A null `fillRule` will cause certain operaions to error out.
+            // So, only set the fill rule if it's one of the two valid options: "evenodd" and "nonzero".
+			if (value === 'evenodd' || value === 'nonzero') item.fillRule = value;
+		}
     });
 
     function getAttribute(node, name, styles) {


### PR DESCRIPTION
### Description

Resolves https://github.com/LLK/scratch-paint/issues/728
Resolves https://github.com/LLK/scratch-paint/issues/907
Resolves https://github.com/LLK/scratch-paint/issues/958

See https://github.com/paperjs/paper.js/issues/1732 for more details.

Essentially, certain items' style values (including `fillRule`) can be undefined. When exporting these undefined style values, they are coerced to `null`, which causes the exporter to set the corresponding XML node's attribute to `none`. This is a problem because `none` is not a valid value for the `fill-rule` attribute, and setting it can cause rendering to fail.

To prevent this, I added a check to the exporter so that it will not add XML attributes for undefined values at all.

I also added a check to the importer so that it will only set items' `fillRule` to valid values. This prevents existing "bad" SVGs from erroring out.