### PR TITLE
Don't set item names in SVG import

### DIFF
--- a/src/svg/SvgImport.js
+++ b/src/svg/SvgImport.js
@@ -445,7 +445,9 @@ new function() {
     }, {}), {
         id: function(item, value) {
             definitions[value] = item;
-            if (item.setName)
+            // Same check used in setName to test if IDs are numeric. Numeric IDs make setName throw an exception.
+            // Better to duplicate the check than to wrap this in a try block & swallow all other potential exceptions.
+            if (item.setName && ((+value) + '' !== value))
                 item.setName(value);
         },
 

--- a/src/svg/SvgImport.js
+++ b/src/svg/SvgImport.js
@@ -445,10 +445,6 @@ new function() {
     }, {}), {
         id: function(item, value) {
             definitions[value] = item;
-            // Same check used in setName to test if IDs are numeric. Numeric IDs make setName throw an exception.
-            // Better to duplicate the check than to wrap this in a try block & swallow all other potential exceptions.
-            if (item.setName && ((+value) + '' !== value))
-                item.setName(value);
         },
 
         'clip-path': function(item, value) {

--- a/test/tests/SvgImport.js
+++ b/test/tests/SvgImport.js
@@ -168,6 +168,16 @@ test('Import SVG string with leading line-breaks', function() {
     }));
 });
 
+test('Import SVG with numeric ID', function() {
+    paper.project.importSVG(createSVG('circle', {
+        cx: 100,
+        cy: 100,
+        r: 50,
+        id: '1'
+    }));
+    ok(true, 'Imports SVG with a numeric element ID without throwing.');
+});
+
 function importSVG(assert, url, message, options) {
     var done = assert.async();
     project.importSVG(url, {


### PR DESCRIPTION
### Description
If an imported SVG item's ID is numeric, just don't set the corresponding Paper.js item's name to it.

A quick look seems to indicate that other SVG import code doesn't rely on items' names being set to corresponding IDs so this should be safe.

#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Resolves https://github.com/LLK/scratch-svg-renderer/issues/53

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
