### PR TITLE
Fix raster smoothing test

### DIFF
--- a/test/tests/Raster.js
+++ b/test/tests/Raster.js
@@ -180,17 +180,17 @@ test('Raster#getAverageColor(path) with compound path', function() {
             { tolerance: 1e-3 });
 });
 
-test('Raster#smoothing defaults to true', function() {
+test('Raster#smoothing defaults to false', function() {
     var raster = new Raster();
-    equals(raster.smoothing, true);
+    equals(raster.smoothing, false);
 });
 
 test('Raster#smoothing', function() {
-    var raster = new Raster({ smoothing: false });
-    equals(raster.smoothing, false);
-
-    raster.smoothing = true;
+    var raster = new Raster({ smoothing: true });
     equals(raster.smoothing, true);
+
+    raster.smoothing = false;
+    equals(raster.smoothing, false);
 });
 
 test('Raster#setSmoothing setting does not impact canvas context', function(assert) {


### PR DESCRIPTION
### Description
This PR adjusts the Raster.smoothing unit test, which is currently the only failing test in the entire suite, to expect the `smoothing` property to default to `false`.

It also changes the "setting `smoothing`" test so that it retains the behavior that was likely intended by the original authors: when first constructing the `Raster`, initialize `smoothing` to the non-default value then change it back to the default.

#### Related issues

- Resolves #35

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
