### PR TITLE
Allow pointer events to be used if supported

### DIFF
--- a/src/view/View.js
+++ b/src/view/View.js
@@ -53,6 +53,8 @@ var View = Base.extend(Emitter, /** @lends View# */{
             DomElement.setPrefixed(element.style, {
                 userDrag: none,
                 userSelect: none,
+                // Prevent pointer events from doing things like panning the page
+                touchAction: none,
                 touchCallout: none,
                 contentZooming: none,
                 tapHighlightColor: 'rgba(0,0,0,0)'
@@ -1069,7 +1071,7 @@ new function() { // Injection scope for event handling on the browser
     // Touch handling inspired by Hammer.js
     var navigator = window.navigator,
         mousedown, mousemove, mouseup;
-    if (navigator.pointerEnabled || navigator.msPointerEnabled) {
+    if (window.PointerEvent || navigator.msPointerEnabled) {
         // HTML5 / MS pointer events
         mousedown = 'pointerdown MSPointerDown';
         mousemove = 'pointermove MSPointerMove';


### PR DESCRIPTION
### Description
This is a port of https://github.com/paperjs/paper.js/pull/1810. See that PR for more details.

Because this re-enables a code path that was previously never taken due to a bug, it should be tested thoroughly across browsers + devices to ensure it doesn't uncover any previously unknown bugs.

#### Related issues

- Resolves https://github.com/LLK/scratch-paint/issues/1055
- Resolves https://github.com/LLK/paper.js/issues/27
- Blocks https://github.com/LLK/scratch-paint/issues/1056

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
