### PR TITLE
Add hitUnstrokedPaths option to hit tests

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -1975,6 +1975,8 @@ new function() { // Injection scope for hit-test functions shared with project
      * @option options.selected {Boolean} only hit selected items
      * @option options.hitUnfilledPaths {Boolean} Allow hitting null or alpha 0
      *     fills for paths
+     * @option options.hitUnstrokedPaths {Boolean} Allow hitting null or alpha 0
+     *     strokes for paths
      *
      * @param {Point} point the point where the hit-test should be performed
      *     (in global coordinates system).

--- a/src/path/Path.js
+++ b/src/path/Path.js
@@ -1665,9 +1665,8 @@ var Path = PathItem.extend(/** @lends Path# */{
             strokePadding = tolerancePadding,
             join, cap, miterLimit,
             area, loc, res,
-            hitStroke = options.stroke && style.hasStroke(),
-            hitFill = options.hitUnfilledPaths
-                ? options.fill : options.fill && style.hasFill(),
+            hitStroke = options.stroke && (style.hasStroke() || options.hitUnstrokedPaths),
+            hitFill = options.fill && (style.hasFill() || options.hitUnfilledPaths),
             hitCurves = options.curves,
             strokeRadius = hitStroke
                     ? style.getStrokeWidth() / 2


### PR DESCRIPTION
### Description
In order to add outline support to the fill tool, there needs to be an option to hit "invisible" outlines.

Otherwise, if you set the fill color to transparent, then hover over a path's outline:
- The hit test will match the outline
- It'll set the outline to transparent
- Because the outline is transparent, hit tests won't match it
- Next time you move the mouse slightly, the hit test will match the fill
- It'll set the fill to transparent and set the outline to whatever color it was before
- The hit test will match the outline, and the process repeats...

It involves a lot of flickering so I won't post a GIF here.

`CompoundPath._hitTestChildren` isn't affected because it only ever disabled checking for fill, and hence was only affected by `hitUnfilledPaths`.

`PointText._hitTestSelf` isn't affected because you can't hit test outlines on text :(

#### Related issues

- Relates to https://github.com/LLK/scratch-paint/issues/540
- Relates to https://github.com/LLK/scratch-paint/pull/1004

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
  - Tested manually
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
