### PR TITLE
Properly render gradients when strokeScaling = false

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -4279,16 +4279,16 @@ new function() { // Injection scope for hit-test functions shared with project
      * Not defined in Path as it is required by other classes too,
      * e.g. PointText.
      */
-    _setStyles: function(ctx, param, viewMatrix) {
+    _setStyles: function(ctx, param, viewMatrix, strokeMatrix) {
         // We can access internal properties since we're only using this on
         // items without children, where styles would be merged.
         var style = this._style,
             matrix = this._matrix;
         if (style.hasFill()) {
-            ctx.fillStyle = style.getFillColor().toCanvasStyle(ctx, matrix);
+            ctx.fillStyle = style.getFillColor().toCanvasStyle(ctx, matrix, strokeMatrix);
         }
         if (style.hasStroke()) {
-            ctx.strokeStyle = style.getStrokeColor().toCanvasStyle(ctx, matrix);
+            ctx.strokeStyle = style.getStrokeColor().toCanvasStyle(ctx, matrix, strokeMatrix);
             ctx.lineWidth = style.getStrokeWidth();
             var strokeJoin = style.getStrokeJoin(),
                 strokeCap = style.getStrokeCap(),

--- a/src/item/Shape.js
+++ b/src/item/Shape.js
@@ -261,7 +261,7 @@ var Shape = Item.extend(/** @lends Shape# */{
             ctx.closePath();
         }
         if (!dontPaint && (hasFill || hasStroke)) {
-            this._setStyles(ctx, param, viewMatrix);
+            this._setStyles(ctx, param, viewMatrix, strokeMatrix);
             if (hasFill) {
                 ctx.fill(style.getFillRule());
                 ctx.shadowColor = 'rgba(0,0,0,0)';

--- a/src/path/CompoundPath.js
+++ b/src/path/CompoundPath.js
@@ -311,7 +311,7 @@ var CompoundPath = PathItem.extend(/** @lends CompoundPath# */{
             children[i].draw(ctx, param, strokeMatrix);
 
         if (!param.clip) {
-            this._setStyles(ctx, param, viewMatrix);
+            this._setStyles(ctx, param, viewMatrix, strokeMatrix);
             var style = this._style;
             if (style.hasFill()) {
                 ctx.fill(style.getFillRule());

--- a/src/path/Path.js
+++ b/src/path/Path.js
@@ -2321,7 +2321,7 @@ new function() { // Scope for drawing
             if (!dontPaint && (hasFill || hasStroke)) {
                 // If the path is part of a compound path or doesn't have a fill
                 // or stroke, there is no need to continue.
-                this._setStyles(ctx, param, viewMatrix);
+                this._setStyles(ctx, param, viewMatrix, strokeMatrix);
                 if (hasFill) {
                     ctx.fill(style.getFillRule());
                     // If shadowColor is defined, clear it after fill, so it

--- a/test/tests/Color.js
+++ b/test/tests/Color.js
@@ -306,6 +306,41 @@ test('Gradients with applyMatrix', function() {
     comparePixels(path, shape);
 });
 
+test('Gradients with strokeScaling: false', function() {
+    var topLeft = [100, 100];
+    var bottomRight = [400, 400];
+    var gradientColor = {
+        gradient: {
+            stops: ['yellow', 'red', 'blue']
+        },
+        origin: topLeft,
+        destination: bottomRight
+    }
+
+    var path = new Shape.Rectangle({
+        topLeft: topLeft,
+        bottomRight: bottomRight,
+        fillColor: gradientColor,
+        strokeScaling: true
+    });
+
+    var shape = new Shape.Rectangle({
+        topLeft: topLeft,
+        bottomRight: bottomRight,
+        fillColor: gradientColor,
+        strokeScaling: false
+    });
+
+    comparePixels(path, shape);
+
+    path.scale(2);
+    path.rotate(45);
+    shape.scale(2);
+    shape.rotate(45);
+
+    comparePixels(path, shape);
+})
+
 test('Modifying group.strokeColor for multiple children', function() {
     var item = new Group(new Path(), new Path());
     item.strokeColor = 'red';


### PR DESCRIPTION
### Description
This was a fun bug :slightly_smiling_face: I like paper.js :slightly_smiling_face: 

See https://github.com/paperjs/paper.js/pull/1822 for more info. This is necessary to make bitmap shape tools work properly with gradients, otherwise this will happen:
![Peek 2020-06-08 14-30](https://user-images.githubusercontent.com/25993062/84095078-52745680-a9cc-11ea-9e14-d8c6d8174e06.gif)


#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Relates to https://github.com/paperjs/paper.js/issues/1821

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
