### PR TITLE
Fix stroke bounds for paths

### DIFF
--- a/src/path/Curve.js
+++ b/src/path/Curve.js
@@ -858,8 +858,8 @@ statics: /** @lends Curve */{
         }
 
         padding /= 2; // strokePadding is in width, not radius
-        var minPad = min[coord] - padding,
-            maxPad = max[coord] + padding;
+        var minPad = min[coord] + padding,
+            maxPad = max[coord] - padding;
         // Perform a rough bounds checking first: The curve can only extend the
         // current bounds if at least one value is outside the min-max range.
         if (    v0 < minPad || v1 < minPad || v2 < minPad || v3 < minPad ||

--- a/test/tests/Item_Bounds.js
+++ b/test/tests/Item_Bounds.js
@@ -798,3 +798,19 @@ test('#1561 item._globalMatrix on item after empty symbol', function(){
     view.update();
     equals(item._globalMatrix, new Matrix());
 });
+
+test('path.strokeBounds applies stroke padding properly (#1824)', function() {
+    var ellipse = new Path.Ellipse({
+        point: [100, 100],
+        size: [50, 80],
+        strokeWidth: 32,
+        strokeColor: 'red'
+    });
+
+    ellipse.rotate(50);
+    equals(
+        ellipse.strokeBounds,
+        new Rectangle(74.39306, 91.93799, 101.21388, 96.12403),
+        'ellipse.strokeBounds'
+    );
+})


### PR DESCRIPTION
### Description
See https://github.com/paperjs/paper.js/pull/1825

#### Related issues

- Resolves https://github.com/LLK/scratch-paint/issues/1121
- Relates to https://github.com/paperjs/paper.js/issues/1824

### Checklist


- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the JSHint rules (`npm run jshint` passes)
